### PR TITLE
Enable i2c for rpi-4

### DIFF
--- a/rpi4-config/config.txt
+++ b/rpi4-config/config.txt
@@ -17,8 +17,10 @@ enable_gic=1
 
 [pi4]
 dtoverlay=vc4-fkms-v3d
+dtparam=i2c_arm=on
 max_framebuffers=2
 arm_64bit=1
+
 
 [all]
 gpu_mem=320

--- a/rpi4/etc/modules
+++ b/rpi4/etc/modules
@@ -1,0 +1,5 @@
+# /etc/modules: kernel modules to load at boot time.
+#
+# This file contains the names of kernel modules that should be loaded
+# at boot time, one per line. Lines beginning with "#" are ignored.
+i2c-dev


### PR DESCRIPTION
Adds device tree parameters and loads i2c module