### PR TITLE
Add i2c to raspberry pi 4

### DIFF
--- a/overlays/rpi4-config/config.txt
+++ b/overlays/rpi4-config/config.txt
@@ -17,6 +17,7 @@ enable_gic=1
 
 [pi4]
 dtoverlay=vc4-fkms-v3d
+dtparam=i2c_arm=on
 max_framebuffers=2
 arm_64bit=1
 

--- a/overlays/rpi4/etc/modules
+++ b/overlays/rpi4/etc/modules
@@ -1,0 +1,5 @@
+# /etc/modules: kernel modules to load at boot time.
+#
+# This file contains the names of kernel modules that should be loaded
+# at boot time, one per line. Lines beginning with "#" are ignored.
+i2c-dev

--- a/recipes/rpi4.yml
+++ b/recipes/rpi4.yml
@@ -66,8 +66,14 @@ actions:
     command: mkdir -p /boot/firmware/overlays && cp -v /usr/lib/linux-image-*/broadcom/*.dtb /boot/firmware && cp -v /usr/lib/linux-image-*/overlays/* /boot/firmware/overlays/
 
   - action: overlay
+    description: Add Raspberry Pi 4 firmware overlay
     source: ../overlays/rpi4-config
     destination: /boot/firmware
+
+  - action: overlay
+    description: Add Raspberry Pi 4 root overlay
+    source: ../overlays/rpi4
+    destination: /
 
   - action: overlay
     origin: firmwarenonfree


### PR DESCRIPTION
- Add config.txt flag to activate the i2c hardware
- Load the i2c-dev module