### PR TITLE
Remove resolve.conf fixes

### DIFF
--- a/overlays/resolv/etc/resolv.conf
+++ b/overlays/resolv/etc/resolv.conf
@@ -1,1 +1,0 @@
-nameserver 8.8.8.8

--- a/recipes/base-packages.yml
+++ b/recipes/base-packages.yml
@@ -30,10 +30,6 @@ actions:
       - i2c-tools
       - rng-tools5
 
-  - action: overlay
-    description: fix DNS inside container
-    source: ../overlays/resolv
-
     # Desktop packages
   - action: apt
     description: Plasma packages
@@ -43,10 +39,6 @@ actions:
       - plasma-widgets-addons
       - libkf5wallet-bin
       - kscreen
-
-  - action: overlay
-    description: fix DNS inside container
-    source: ../overlays/resolv
 
   - action: apt
     description: Networking packages


### PR DESCRIPTION
The new debos image doesn't need the manual restore of resolve.conf.