### PR TITLE
Move the mycroft.conf to the platform overlay

### DIFF
--- a/overlays/mark2/etc/mycroft/mycroft.conf
+++ b/overlays/mark2/etc/mycroft/mycroft.conf
@@ -1,6 +1,6 @@
 {
   "enclosure": {
-    "platform": "respeaker",
+    "platform": "mycroft_mark_2",
     "platform_build": 1
   },
   "ipc_path": "/ramdisk/mycroft/ipc/",


### PR DESCRIPTION
The defauit conf should be in the paltform specific ovelay this makes it easier to handle the platform info. This moves the existing system level default to the mark2 overlay and sets the matching platform value.