### PR TITLE
Add Mycroft helper commands

### DIFF
--- a/overlays/helper-commands/.mycroftrc
+++ b/overlays/helper-commands/.mycroftrc
@@ -1,0 +1,2 @@
+# Add Mycroft helper commands to $PATH
+export PATH="/home/$USER/mycroft-core/bin:$PATH"

--- a/recipes/base-embedded.yml
+++ b/recipes/base-embedded.yml
@@ -10,3 +10,7 @@ actions:
     description: Mycroft Mark 2 specific overlay
     source: ../overlays/base-embedded
 
+  - action: overlay
+    description: Mycroft helper commands overlay
+    source: ../overlays/helper-commands
+    destination: /opt/mycroft/

--- a/scripts/92-clone-mycroft.sh
+++ b/scripts/92-clone-mycroft.sh
@@ -5,6 +5,9 @@ USER=mycroft
 tar -xzf /var/tmp/mycroft-core-setup-aarch64.tar.gz -C /home/$USER/
 rm /var/tmp/mycroft-core-setup-aarch64.tar.gz
 
+# Add Mycroft helper commands to $PATH
+echo 'source /opt/mycroft/.mycroftrc' >> /home/$USER/.bashrc
+
 mkdir -p /opt/mycroft/skills
 mkdir -p /var/log/mycroft
 mkdir -p /home/$USER/.mycroft


### PR DESCRIPTION
Adds the `mycroft-core/bin` directory to $PATH by appending to `.bashrc`, providing quick access to the Mycroft helper commands.