### PR TITLE
gstreamer for focal

### DIFF
--- a/mycroft-mark2-rpi4-ubuntu.yml
+++ b/mycroft-mark2-rpi4-ubuntu.yml
@@ -39,6 +39,14 @@ actions:
       image: {{ $image }}
 
   - action: recipe
+    recipe: recipes/gstreamer-packages.yml
+    variables:
+      architecture: {{ $architecture }}
+      firmware_version: {{ $firmware_version }}
+      suite: {{ $suite }}
+      image: {{ $image }}
+
+  - action: recipe
     recipe: recipes/base-embedded.yml
     variables:
       architecture: {{ $architecture }}

--- a/recipes/gstreamer-packages.yml
+++ b/recipes/gstreamer-packages.yml
@@ -13,6 +13,5 @@ actions:
       - gstreamer1.0-plugins-good
       - gstreamer1.0-plugins-bad
       - gstreamer1.0-plugins-ugly
-      - gstreamer1.0-fluendo-mp3
       - gstreamer1.0-libav
       - libqt5multimedia5-plugins


### PR DESCRIPTION
This adds the gstreamer receipe to the focal image building. Should resolve #34.

This removes the gstreamer-fluendo-mp3 package which is not available nor needed with gstreamer-1.0. (https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=899838)

Above is true for Focal at least but I'm not 100% sure of Neon. Should a the fluendo package be added to one a neon-extras recipe package?