### PR TITLE
Make root device settable when generating the image

### DIFF
--- a/overlays/rpi4-config/cmdline.txt
+++ b/overlays/rpi4-config/cmdline.txt
@@ -1,1 +1,1 @@
-snd_bcm2835.enable_headphones=1 snd_bcm2835.enable_hdmi=1 snd_bcm2835.enable_compat_alsa=0 dwc_otg.lpm_enable=0 console=serial0,115200 console=tty1 fsck.repair=yes fsck.mode=auto root=/dev/mmcblk0p2 rootfstype=ext4 elevator=deadline rootwait
+snd_bcm2835.enable_headphones=1 snd_bcm2835.enable_hdmi=1 snd_bcm2835.enable_compat_alsa=0 dwc_otg.lpm_enable=0 console=serial0,115200 console=tty1 fsck.repair=yes fsck.mode=auto root=@@root_dev@@ rootfstype=ext4 elevator=deadline rootwait

--- a/recipes/rpi4.yml
+++ b/recipes/rpi4.yml
@@ -80,6 +80,12 @@ actions:
     chroot: true
     script: ../scripts/01-pi_copy_kernel.sh
 
+  - action: run
+    description: Set root device in cmdline.txt
+    chroot: true
+    script: ../scripts/011-set_root_fs.sh
+
+
   - action: image-partition
     imagename: {{ $image }}
     imagesize: 8GB

--- a/scripts/011-set_root_fs.sh
+++ b/scripts/011-set_root_fs.sh
@@ -1,0 +1,6 @@
+#! /usr/bin/env bash
+
+ROOT_DEV=${ROOT_DEV:-"/dev/mmcblk0p2"}
+
+# Set boot device
+sed -i "s#@@root_dev@@#$ROOT_DEV#g" /boot/firmware/cmdline.txt


### PR DESCRIPTION
Set root fs device using environment variable. For example use -e ROOT_DEV:/dev/sda2 when building to be used on usb memory.

A complete commandline would be:

```
docker run --rm --device /dev/kvm --user $(id -u)  --group-add=$(getent group kvm | cut -d : -f 3) --workdir /recipes --mount "type=bind,source=$(pwd),destination=/recipes" --security-opt label=disable godebos/debos -e ROOT_DEV:/dev/sda1 mycroft-mark2-rpi4-ubuntu.yml -m 7524M
```