### PR TITLE
Preload Precise engine and model

### DIFF
--- a/mycroft-mark2-rpi4-ubuntu.yml
+++ b/mycroft-mark2-rpi4-ubuntu.yml
@@ -2,6 +2,7 @@
 {{- $firmware_version := or .firmware_version "master" -}}
 {{ $suite :=  or .suite "focal" }}
 {{- $image := or .image "mycroft-mark2-rpi4-ubuntu.img" -}}
+{{- $user := or .user "mycroft" -}}
 
 architecture: {{ $architecture }}
 
@@ -61,6 +62,12 @@ actions:
       firmware_version: {{ $firmware_version }}
       suite: {{ $suite }}
       image: {{ $image }}
+
+  - action: recipe
+    recipe: recipes/load-precise.yml
+    variables:
+      architecture: {{ $architecture }}
+      user: {{ $user }}
 
   - action: recipe
     recipe: recipes/mark2.yml

--- a/recipes/load-precise.yml
+++ b/recipes/load-precise.yml
@@ -1,0 +1,44 @@
+{{- $architecture := or .architecture "arm64" -}}
+{{- $user := or .user "mycroft" -}}
+
+architecture: {{ $architecture }}
+
+actions:
+  - action: run
+    chroot: true
+    command: mkdir -p /home/{{ $user }}/.mycroft/precise
+
+  - action: download
+    url: https://github.com/MycroftAI/precise-data/raw/dist/aarch64/precise-engine_0.3.0_aarch64.tar.gz
+    unpack: false
+    name: precise-engine
+
+  - action: overlay
+    origin: precise-engine
+    source: .
+    destination: /home/{{ $user }}/.mycroft/precise/precise-engine_0.3.0_aarch64.tar.gz
+
+  - action: run
+    description: Unpack Precise engine
+    chroot: true
+    command: tar -xzf /home/{{ $user }}/.mycroft/precise/precise-engine_0.3.0_aarch64.tar.gz -C /home/{{ $user }}/.mycroft/precise
+
+  - action: download
+    url: http://raw.githubusercontent.com/MycroftAI/precise-data/models/hey-mycroft.tar.gz
+    unpack: false
+    name: precise-model
+
+  - action: overlay
+    origin: precise-model
+    source: .
+    destination: /home/{{ $user }}/.mycroft/precise/hey-mycroft.tar.gz
+
+  - action: run
+    description: Unpack Precise model
+    chroot: true
+    command: tar -xzf /home/{{ $user }}/.mycroft/precise/hey-mycroft.tar.gz -C /home/{{ $user }}/.mycroft/precise
+
+  - action: run
+    description: Set ownership of Precise directory and contents
+    chroot: true
+    command: chown -R {{ $user }}:{{ $user }} /home/{{ $user }}/.mycroft/precise

--- a/recipes/mycroft.yml
+++ b/recipes/mycroft.yml
@@ -2,10 +2,11 @@
 {{- $firmware_version := or .firmware_version "master" -}}
 {{ $suite :=  or .suite "bionic" }}
 {{- $image := or .image "mycroft-mark2-rpi4.img" -}}
+{{- $user := or .user "mycroft" -}}
 
 architecture: {{ $architecture }}
 
-actions:  
+actions:
   - action: overlay
     description: Mycroft Mark 2 specific overlay
     source: ../overlays/mycroft
@@ -61,3 +62,8 @@ actions:
     chroot: true
     script: ../scripts/92-clone-mycroft.sh
 
+  - action: recipe
+    recipe: load-precise.yml
+    variables:
+      architecture: {{ $architecture }}
+      user: {{ $user }}

--- a/recipes/mycroft.yml
+++ b/recipes/mycroft.yml
@@ -2,7 +2,6 @@
 {{- $firmware_version := or .firmware_version "master" -}}
 {{ $suite :=  or .suite "bionic" }}
 {{- $image := or .image "mycroft-mark2-rpi4.img" -}}
-{{- $user := or .user "mycroft" -}}
 
 architecture: {{ $architecture }}
 
@@ -61,9 +60,3 @@ actions:
     description: Install mycroft base software
     chroot: true
     script: ../scripts/92-clone-mycroft.sh
-
-  - action: recipe
-    recipe: load-precise.yml
-    variables:
-      architecture: {{ $architecture }}
-      user: {{ $user }}


### PR DESCRIPTION
This packages the Precise engine and default model in the image so it doesn't need to be downloaded on first boot.

Is stage 1 of #29 