### PR TITLE
Get architecture dependent tarball

### DIFF
--- a/recipes/mycroft.yml
+++ b/recipes/mycroft.yml
@@ -12,14 +12,14 @@ actions:
 
   - action: download
 #TODO: need up to date arm64 and arm32 mycroft-core tarballs
-    url: https://frozenmazegames.se/mycroft-core-setup-aarch64-{{ $suite }}.tar.gz
+    url: https://frozenmazegames.se/mycroft-core-setup-{{ $architecture }}-{{ $suite }}.tar.gz
     name: mycroft-core
-    filename: mycroft-core-setup-aarch64.tar.gz
+    filename: mycroft-core-setup.tar.gz
 
   - action: overlay
     origin: mycroft-core
     source: .
-    destination: /var/tmp/mycroft-core-setup-aarch64.tar.gz
+    destination: /var/tmp/mycroft-core-setup.tar.gz
 
   - action: apt
     description: Mycroft runtime dependencies

--- a/scripts/92-clone-mycroft.sh
+++ b/scripts/92-clone-mycroft.sh
@@ -2,8 +2,8 @@ UGID=32011
 USER=mycroft
 
 # Unpack mycroft-core-setup-aarch64.tar.gz to user home
-tar -xzf /var/tmp/mycroft-core-setup-aarch64.tar.gz -C /home/$USER/
-rm /var/tmp/mycroft-core-setup-aarch64.tar.gz
+tar -xzf /var/tmp/mycroft-core-setup.tar.gz -C /home/$USER/
+rm /var/tmp/mycroft-core-setup.tar.gz
 
 mkdir -p /opt/mycroft/skills
 mkdir -p /var/log/mycroft


### PR DESCRIPTION
#### Description
Uses the architecture variable to build the tar-ball name.

#### Type of PR
- [ ] Bugfix
- [ x ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Build an image and make sure it get's a mycroft-core tarball