### PR TITLE
Bumps image size for 16GB USB drives

### DIFF
--- a/recipes/rpi4.yml
+++ b/recipes/rpi4.yml
@@ -99,7 +99,7 @@ actions:
 
   - action: image-partition
     imagename: {{ $image }}
-    imagesize: 8GB
+    imagesize: 15.4GB
     partitiontype: msdos
     mountpoints:
       - mountpoint: /


### PR DESCRIPTION
We are defaulting to 16GB USB drives (15.4GB of usable space).

This increases the default partition size to take up the entire disk. Could make this a commandline variable but unlikely to change regularly right now.
